### PR TITLE
音量設定が0でも1で鳴る問題を修正。その他細かい挙動を変更。

### DIFF
--- a/PicoAudio.js
+++ b/PicoAudio.js
@@ -788,7 +788,7 @@ var PicoAudio = (function(){
 				reserveSongEnd = setTimeout(reserveSongEndFunc, 1);
 				that.pushFunc({
 					rootTimeout: reserveSongEnd,
-					stopFunc: function(){ clearTimeout(reserveSongEndAgain); }
+					stopFunc: function(){ clearTimeout(reserveSongEnd); }
 				});
 			}
 		};

--- a/PicoAudio.js
+++ b/PicoAudio.js
@@ -8,8 +8,8 @@ var PicoAudio = (function(){
 			tempo: 120,
 			basePitch: 440,
 			resolution: 480,
-			hashLength: 1000,
-			hashBuffer: 1,
+			hashLength: this.isAndroid() ? 25 : 50,
+			hashBuffer: 2,
 			isWebMIDI: false,
 			WebMIDIPortOutputs: null,
 			WebMIDIPortOutput: null,
@@ -221,7 +221,7 @@ var PicoAudio = (function(){
 		}
 
 		if((oscillator.type == "sine" || oscillator.type == "triangle")
-			&& !isPizzicato && note.stop - note.start > 0.1){
+			&& !isPizzicato && note.stop - note.start > 0.01){
 			// 終わり際に少し減衰しノイズ削減
 			noiseCutGainNode.gain.setValueAtTime(1, note.stop-0.005);
 			noiseCutGainNode.gain.linearRampToValueAtTime(0, note.stop);

--- a/PicoAudio.js
+++ b/PicoAudio.js
@@ -1202,7 +1202,7 @@ var PicoAudio = (function(){
 									case 0x20:
 										break;
 									case 0x2F:
-										time += (this.isSkipEnding ? 0 : header.resolution) - dt;
+										time += (this.settings.isSkipEnding ? 0 : header.resolution) - dt;
 										break;
 									// Tempo
 									case 0x51:


### PR DESCRIPTION
・Picotuneにある最新版PicoAudio.jsをコミット
・軽微なバグ修正
・設定値の変更

・音量設定が0でも1で鳴る問題を修正
・ピッチカート系減衰の軽量化
　・ピッチカート系減衰は0.5秒間ノートオンしていたが、実質音が鳴るのは0.2秒間なので0.2秒間ノートオンするように変更
・バッファの長さ設定をAndroidは25→20、それ以外は50→30に変更
・音量が常に0の場合は音を鳴らさないように変更（処理負担の軽量化）

・終端スキップのミス修正（2018/01/29 追記）
（PicoAudio.jsの追加コミットをして新しくなったので、Picotune修正パッチの方のPicoAudio.jsは使わないでください）