### PR TITLE
CC111を使った場合のループの終了タイミングを最後のEventに変更

### DIFF
--- a/src/player/play.js
+++ b/src/player/play.js
@@ -53,7 +53,7 @@ export default function play(isSongLooping) {
     let reserveSongEnd;
     const reserveSongEndFunc = () => {
         this.clearFunc("rootTimeout", reserveSongEnd);
-        const finishTime = (settings.isCC111 && this.cc111Time != -1) ? this.lastNoteOffTime : this.getTime(Number_MAX_SAFE_INTEGER);
+        const finishTime = (settings.isCC111 && this.cc111Time != -1) ? this.lastEventTime : this.getTime(Number_MAX_SAFE_INTEGER);
         if (finishTime - context.currentTime + states.startTime <= 0) {
             // 予定の時間以降に曲終了
             trigger.songEnd();
@@ -69,7 +69,7 @@ export default function play(isSongLooping) {
         }
     };
     const finishTime = settings.isCC111 && this.cc111Time != -1
-        ? this.lastNoteOffTime
+        ? this.lastEventTime
         : this.getTime(Number_MAX_SAFE_INTEGER);
     const reserveSongEndTime = (finishTime - context.currentTime + states.startTime) * 1000;
     reserveSongEnd = setTimeout(reserveSongEndFunc, reserveSongEndTime);

--- a/src/player/play.js
+++ b/src/player/play.js
@@ -53,7 +53,7 @@ export default function play(isSongLooping) {
     let reserveSongEnd;
     const reserveSongEndFunc = () => {
         this.clearFunc("rootTimeout", reserveSongEnd);
-        const finishTime = (settings.isCC111 && this.cc111Time != -1) ? this.lastEventTime : this.getTime(Number_MAX_SAFE_INTEGER);
+        const finishTime = this.getTime(Number_MAX_SAFE_INTEGER);
         if (finishTime - context.currentTime + states.startTime <= 0) {
             // 予定の時間以降に曲終了
             trigger.songEnd();
@@ -68,9 +68,7 @@ export default function play(isSongLooping) {
             });
         }
     };
-    const finishTime = settings.isCC111 && this.cc111Time != -1
-        ? this.lastEventTime
-        : this.getTime(Number_MAX_SAFE_INTEGER);
+    const finishTime = this.getTime(Number_MAX_SAFE_INTEGER);
     const reserveSongEndTime = (finishTime - context.currentTime + states.startTime) * 1000;
     reserveSongEnd = setTimeout(reserveSongEndFunc, reserveSongEndTime);
     this.pushFunc({

--- a/src/player/set-data.js
+++ b/src/player/set-data.js
@@ -16,6 +16,8 @@ export default function setData(data) {
     this.lastNoteOffTiming = data.lastNoteOffTiming;
     this.firstNoteOnTime = data.firstNoteOnTime;
     this.lastNoteOffTime = data.lastNoteOffTime;
+    this.lastEventTiming = data.lastEventTiming;
+    this.lastEventTime = data.lastEventTime;
     this.initStatus();
 
     if (this.debug) {

--- a/src/smf/parse-smf.js
+++ b/src/smf/parse-smf.js
@@ -49,6 +49,8 @@ export default function parseSMF(_smf) {
     data.firstNoteOnTime = info.firstNoteOnTime;
     data.lastNoteOffTiming = info.lastNoteOffTiming;
     data.lastNoteOffTime = info.lastNoteOffTime;
+    data.lastEventTiming = info.lastEventTiming;
+    data.lastEventTime = info.lastEventTime;
     if (this.settings.isWebMIDI) {
         data.messages = info.messages;
         data.smfData = new Uint8Array(smf); // lastStateを上書きしたsmfをコピー

--- a/src/smf/parse-smf/parse-event.js
+++ b/src/smf/parse-smf/parse-event.js
@@ -19,6 +19,8 @@ export default function parseEvent(info) {
     let firstNoteOnTime = Number_MAX_SAFE_INTEGER;
     let lastNoteOffTiming = 0; // 最後のノートオフのTick
     let lastNoteOffTime = 0;
+    let lastEventTiming = 0; // 最後のEventのTick
+    let lastEventTime = 0;
 
     // Midi Events (0x8n - 0xEn) parse
     for (let ch=0; ch<16; ch++) {
@@ -310,6 +312,12 @@ export default function parseEvent(info) {
                 }
             }
             indIdx = nextIdx;
+
+            // 最後のEventを記録
+            if (tick > lastEventTiming) {
+                lastEventTiming = tick;
+                lastEventTime = time;
+            }
         }
         channel.nowNoteOnIdxAry = nowNoteOnIdxAry;
         if (!this.debug) {
@@ -386,6 +394,8 @@ export default function parseEvent(info) {
     info.firstNoteOnTime = firstNoteOnTime;
     info.lastNoteOffTiming = lastNoteOffTiming;
     info.lastNoteOffTime = lastNoteOffTime;
+    info.lastEventTiming = lastEventTiming;
+    info.lastEventTime = lastEventTime;
     if (this.settings.isWebMIDI) {
         info.messages = messages;
         info.smfData = new Uint8Array(smf); // lastStateを上書きしたsmfをコピー

--- a/src/smf/parse-smf/parse-event.js
+++ b/src/smf/parse-smf/parse-event.js
@@ -351,6 +351,7 @@ export default function parseEvent(info) {
         delete channel.nowNoteOnIdxAry;
     }
     if (this.settings.isSkipEnding) songLength = lastNoteOffTiming;
+    if (this.settings.isCC111 && cc111Time != -1) songLength = lastEventTiming;
     tempoTrack.push({ timing:songLength, time:(60 / tempo / header.resolution) * (songLength - tempoCurTick) + tempoCurTime, value:120 });
 
     // WebMIDI用のMIDIメッセージを作成 //


### PR DESCRIPTION
# 変更点

- CC111を使用している場合、再生終了コールバックの発生するタイミングを最後のイベントを再生した直後に変更。

RPGツクールの仕様ではend of truckメッセージまで再生する仕様になっているらしく、最後のEventまで再生しないとループのタイミングがおかしくなることがある。